### PR TITLE
Test app without websockets

### DIFF
--- a/requirements_simple.txt
+++ b/requirements_simple.txt
@@ -1,0 +1,14 @@
+Flask==2.3.3
+Flask-SQLAlchemy==3.0.5
+Flask-Login==0.6.3
+Flask-WTF==1.1.1
+Flask-Migrate==4.0.5
+Flask-CORS==4.0.0
+WTForms==3.0.1
+email-validator==2.0.0
+Werkzeug==2.3.7
+Jinja2==3.1.2
+MarkupSafe==2.1.3
+itsdangerous==2.1.2
+click==8.1.7
+blinker==1.6.3

--- a/run_simple.py
+++ b/run_simple.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""
+Файл для запуска EduVerse без WebSocket функциональности
+Использует стандартный Flask без SocketIO
+"""
+
+import os
+import sys
+from app_simple import app
+
+if __name__ == '__main__':
+    # Проверка переменных окружения
+    if not os.getenv('SECRET_KEY'):
+        print("⚠️  SECRET_KEY не установлен, используется значение по умолчанию")
+        print("Для продакшена установите переменную окружения SECRET_KEY")
+    
+    # Настройки для запуска
+    port = int(os.getenv('PORT', 5000))
+    host = os.getenv('HOST', '0.0.0.0')
+    debug = os.getenv('DEBUG', 'True').lower() == 'true'
+    
+    print(f"🚀 Запуск EduVerse (без WebSocket) на {host}:{port}")
+    print(f"🔧 Режим отладки: {'Включен' if debug else 'Отключен'}")
+    print(f"📱 Доступно по адресу: http://localhost:{port}")
+    
+    try:
+        # Запуск приложения
+        app.run(
+            host=host,
+            port=port,
+            debug=debug,
+            use_reloader=debug
+        )
+    except KeyboardInterrupt:
+        print("\n👋 EduVerse остановлен пользователем")
+    except Exception as e:
+        print(f"❌ Ошибка запуска: {e}")
+        sys.exit(1)


### PR DESCRIPTION
Add `run_simple.py` and `requirements_simple.txt` to enable running the application without WebSocket functionality.

The original setup encountered an `AttributeError: module 'ssl' has no attribute 'wrap_socket'` when `Flask-SocketIO` attempted to use `eventlet`, which has compatibility issues with the `ssl` module in certain environments. This PR provides a direct Flask run alternative using the existing `app_simple.py` to bypass the SocketIO/eventlet dependency.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc866ca1-f9c5-4a04-ab03-cdc470b68ee6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bc866ca1-f9c5-4a04-ab03-cdc470b68ee6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

